### PR TITLE
fix issue when condition 'is greater than' does not working

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -998,7 +998,6 @@ class Csv {
         $operators = array(
             '=',
             'equals',
-            'is',
             '!=',
             'is not',
             '<',
@@ -1037,7 +1036,7 @@ class Csv {
             }
 
             if (array_key_exists($field, $row)) {
-                if (($op == '=' || $op == 'equals' || $op == 'is') && $row[$field] == $value) {
+                if (($op == '=' || $op == 'equals') && $row[$field] == $value) {
                     return '1';
                 } elseif (($op == '!=' || $op == 'is not') && $row[$field] != $value) {
                     return '1';


### PR DESCRIPTION
example with default **_books.csv**: 

```
$csv = new ParseCsv\Csv();
$csv->conditions = 'rating is greater than 0';
$csv->limit = 3;
$csv->auto('examples/_books.csv');
print_r($csv->data);
```

return:
```
Array
(
)
```

fix issue:
```
Array
(
    [0] => Array
        (
            [rating] => 3
            [title] => The Last Templar
            [author] => Raymond Khoury
            [type] => Book
            [asin] => 0752880705
            [tags] => 
            [review] => 
        )

    [1] => Array
        (
            [rating] => 5
            [title] => The Traveller
            [author] => John Twelve Hawks
            [type] => Book
            [asin] => 059305430X
            [tags] => 
            [review] => 
        )

    [2] => Array
        (
            [rating] => 4
            [title] => Crisis Four
            [author] => Andy Mcnab
            [type] => Book
            [asin] => 0345428080
            [tags] => 
            [review] => 
        )
)
```